### PR TITLE
loaded the os data from a json file.

### DIFF
--- a/app/src/components/DownloadSection.jsx
+++ b/app/src/components/DownloadSection.jsx
@@ -1,30 +1,34 @@
 import React from "react";
+import { windows, macos, linux } from "../data/osinfo.json";
 import { BsDownload } from "react-icons/bs";
 
 const DownloadSection = () => {
   return (
     <div className="grid grid-cols-3 gap-3 p-6">
       <DownloadItem
-        title={"Microsoft Windows"}
-        text={"Download Windows executable file."}
-        link={"#"}
+        title={windows.title}
+        text={windows.description}
+        format={windows.format}
+        link={windows.source}
       />{" "}
       <DownloadItem
-        title={"Apple MacOS"}
-        text={"Download MacOS disk image file."}
-        link={"#"}
+        title={macos.title}
+        text={macos.description}
+        format={macos.format}
+        link={macos.source}
       />{" "}
       <DownloadItem
-        title={"Linux"}
-        text={"Download debian installer file."}
-        link={"#"}
+        title={linux.title}
+        text={linux.description}
+        format={linux.format}
+        link={linux.source}
       />
     </div>
   );
 };
 
 const DownloadItem = (props) => {
-  const { title, text, link } = props;
+  const { title, text, link, format } = props;
 
   return (
     <div className="bg-slate-50 rounded p-6">
@@ -34,7 +38,7 @@ const DownloadItem = (props) => {
         className="bg-slate-200 inline-flex justify-center items-center px-5 py-2 rounded-full gap-2 hover:bg-slate-300 my-2 font-medium transition-transform active:bg-slate-400 active:scale-95"
         href={link}
       >
-        Download <BsDownload />
+        Download {format} <BsDownload />
       </a>
     </div>
   );

--- a/app/src/data/osinfo.json
+++ b/app/src/data/osinfo.json
@@ -1,0 +1,20 @@
+{
+  "windows": {
+    "title": "Microsoft Windows",
+    "description": "Download for Microsoft Windows.",
+    "format": ".exe",
+    "source": "#"
+  },
+  "macos": {
+    "title": "Apple MacOS",
+    "description": "Download for Apple MacOS.",
+    "format": ".dmg",
+    "source": "#"
+  },
+  "linux": {
+    "title": "Linux",
+    "description": "Download for Ubuntu/Debian systems.",
+    "format": ".deb",
+    "source": "#"
+  }
+}


### PR DESCRIPTION
# problem
before this commit, the operating system data was loaded from the `components/DownloadSection.jsx` file itself as strings.

# change
operating system data is now loaded from `osinfo.json` file in the `src/data` folder.
